### PR TITLE
Fix #378 - enforces-shorthand does not work for h- & w- when prefixed

### DIFF
--- a/lib/rules/enforces-shorthand.js
+++ b/lib/rules/enforces-shorthand.js
@@ -243,7 +243,7 @@ module.exports = {
           }
           // Test if the body of the class matches, eg. 'h-' inside 'h-10'
           if (mode === 'value') {
-            const bodyMatch = inputSet.some((inputClassPattern) => inputClassPattern === remainingClass.body);
+            const bodyMatch = inputSet.some((inputClassPattern) => `${mergedConfig.prefix}${inputClassPattern}` === remainingClass.body);
             if ([undefined, null].includes(mergedConfig.theme.size)) {
               return false;
             }


### PR DESCRIPTION
# Pull Request Name

## Description

Fixes #378

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
